### PR TITLE
fix: request json key shall match expected key in entropy

### DIFF
--- a/internal/server/v1/firehose/actions.go
+++ b/internal/server/v1/firehose/actions.go
@@ -86,7 +86,7 @@ func (api *firehoseAPI) handleStart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	params := struct {
-		StopTime *time.Time
+		StopTime *time.Time `json:"stop_time"`
 	}{}
 
 	// for LOG sinkType, updating stop_time


### PR DESCRIPTION
entropy expects the json key for StopTime to be stop_time