### PR TITLE
fix: always empty body

### DIFF
--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -125,6 +125,10 @@ func requestLogger(lg *zap.Logger) middleware {
 			}
 
 			buf, err := io.ReadAll(req.Body)
+			if err != nil {
+				lg.Debug("error reading request body: %v", zap.String("error", err.Error()))
+				return
+			}
 			reader := io.NopCloser(bytes.NewBuffer(buf))
 			req.Body = reader
 
@@ -148,9 +152,7 @@ func requestLogger(lg *zap.Logger) middleware {
 			case http.MethodGet:
 				break
 			default:
-				if err != nil {
-					lg.Debug("error reading request body: %v", zap.String("error", err.Error()))
-				} else if len(buf) > 0 {
+				if len(buf) > 0 {
 					dst := &bytes.Buffer{}
 					err := json.Compact(dst, buf)
 					if err != nil {

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -127,6 +127,7 @@ func requestLogger(lg *zap.Logger) middleware {
 			bodyBytes, err := io.ReadAll(req.Body)
 			if err != nil {
 				lg.Debug("error reading request body: %v", zap.String("error", err.Error()))
+				return
 			}
 			reader := io.NopCloser(bytes.NewBuffer(bodyBytes))
 			req.Body = reader

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -124,11 +124,7 @@ func requestLogger(lg *zap.Logger) middleware {
 				}{wrapped, flusher}
 			}
 
-			buf, err := io.ReadAll(req.Body)
-			if err != nil {
-				lg.Debug("error reading request body: %v", zap.String("error", err.Error()))
-				return
-			}
+			buf, _ := io.ReadAll(req.Body)
 			reader := io.NopCloser(bytes.NewBuffer(buf))
 			req.Body = reader
 

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -126,7 +126,7 @@ func requestLogger(lg *zap.Logger) middleware {
 
 			bodyBytes, err := io.ReadAll(req.Body)
 			if err != nil {
-				lg.Debug("error reading request body: %v", zap.String("error", err.Error()))
+				lg.Error("error reading request body: %v", zap.String("error", err.Error()))
 				return
 			}
 			reader := io.NopCloser(bytes.NewBuffer(bodyBytes))
@@ -152,7 +152,7 @@ func requestLogger(lg *zap.Logger) middleware {
 				dst := bytes.NewBuffer(nil)
 				err = json.Compact(dst, bodyBytes)
 				if err != nil {
-					lg.Debug("error json compacting request body: %v", zap.String("error", err.Error()))
+					lg.Error("error json compacting request body: %v", zap.String("error", err.Error()))
 				} else {
 					fields = append(fields, zap.String("request_body", dst.String()))
 				}

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -124,6 +124,10 @@ func requestLogger(lg *zap.Logger) middleware {
 				}{wrapped, flusher}
 			}
 
+			buf, err := io.ReadAll(req.Body)
+			reader := io.NopCloser(bytes.NewBuffer(buf))
+			req.Body = reader
+
 			next.ServeHTTP(fr, req)
 
 			if req.URL.Path == "/ping" {
@@ -144,7 +148,6 @@ func requestLogger(lg *zap.Logger) middleware {
 			case http.MethodGet:
 				break
 			default:
-				buf, err := io.ReadAll(req.Body)
 				if err != nil {
 					lg.Debug("error reading request body: %v", zap.String("error", err.Error()))
 				} else if len(buf) > 0 {


### PR DESCRIPTION
- since body was read once by the ServeHTTP method, it was always empty when we re-read it for logging
- storing the body in a varibale which is later logged